### PR TITLE
Improve RabbitMQ connection reliability and error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "exabgp_process"
-version = "1.0.4"
+version = "1.0.5"
 description = "Process for ExaBGP, started by ExaBGP service"
 readme = "README.md" 
 authors = [


### PR DESCRIPTION
- Switch from auto_ack to manual ACK/NACK: messages are acknowledged only after successful stdout write, preventing silent message loss on process crash
- Add try/except around JSON parsing and key access in callback: malformed messages are rejected (basic_nack requeue=False) instead of crashing the process; unexpected errors requeue for redelivery
- Add SIGTERM handler for graceful shutdown under systemd/Docker
- Handle AMQPConnectionError on initial connect and during consuming: process now survives RabbitMQ being unavailable (container restart, rebuild) and retries every 15 seconds until broker is back
- Add log messages to all reconnect and error paths